### PR TITLE
Log API errors instead of throwing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -82,7 +82,7 @@ app.use((req, res, next) => {
     const message = err.message || "Internal Server Error";
 
     res.status(status).json({ message });
-    throw err;
+    console.error(err);
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- log errors in server middleware instead of rethrowing

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844b6951548832095a99ff143fb73a4